### PR TITLE
Block version check fix in SetBestChain()

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1920,7 +1920,7 @@ bool SetBestChain(CValidationState &state, CBlockIndex* pindexNew)
         const CBlockIndex* pindex = pindexBest;
         for (int i = 0; i < 100 && pindex != NULL; i++)
         {
-            if (pindex->nVersion > CBlock::CURRENT_VERSION)
+            if (pindex->nVersion > CBlock::CURRENT_VERSION && !IsAuxPowVersion(pindex->nVersion))
                 ++nUpgraded;
             pindex = pindex->pprev;
         }
@@ -2009,6 +2009,13 @@ int GetAuxPowStartBlock()
 int GetOurChainID()
 {
     return 0x0018;
+}
+
+bool IsAuxPowVersion(int nVersion)
+{
+    int nBareAuxPowVersion = CBlockHeader::CURRENT_VERSION | (GetOurChainID() * BLOCK_VERSION_CHAIN_START);
+    return (nVersion == (nBareAuxPowVersion | BLOCK_VERSION_AUXPOW) ||
+        nVersion == (nBareAuxPowVersion & ~BLOCK_VERSION_AUXPOW));
 }
 
 bool CBlockHeader::CheckProofOfWork(int nHeight) const

--- a/src/main.h
+++ b/src/main.h
@@ -181,7 +181,10 @@ int GetNumBlocksOfPeers();
 bool IsInitialBlockDownload();
 /** Format a string that describes several potential problems detected by the core */
 std::string GetWarnings(std::string strFor);
+/** AuxPoW Chain ID */
 int GetOurChainID();
+/** Determine whether the block version is modulated with auxpow logic */
+bool IsAuxPowVersion(int nVersion);
 /** Retrieve a transaction (from memory pool, or from disk, if possible) */
 bool GetTransaction(const uint256 &hash, CTransaction &tx, uint256 &hashBlock, bool fAllowSlow = false);
 /** Connect/disconnect blocks until pindexNew is the new tip of the active block chain */


### PR DESCRIPTION
Fix the block version check in SetBestChain() to not regard aux blocks as a higher version than the regular block version. fixes #38
